### PR TITLE
fix: Avoid CancelledError from being propagated to lifespan's receive()

### DIFF
--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -84,6 +84,11 @@ class LifespanOn:
                 "state": self.state,
             }
             await app(scope, self.receive, self.send)
+        except asyncio.CancelledError:
+            # Lifespan task was cancelled, likely due to the server shutting down.
+            # This is not an error that should be handled by BaseException above,
+            # so we just log it and exit.
+            self.logger.info("Lifespan task cancelled.")
         except BaseException as exc:
             self.asgi = None
             self.error_occured = True


### PR DESCRIPTION
# Summary

Currently `LifeSpanOn.main()` is excepting `BaseException`, which also catches `CancelledError`.

`CancelledError` is used by `asyncio` to signal that a task has been cancelled and is not an error condition.

This commit changes the behavior to catch `CancelledError` separately and log it as a "Lifespan task cancelled" instead of letting the error propagate.

# Checklist

- [ x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ x ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
